### PR TITLE
update to 5.0.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hsluv" %}
-{% set version = "5.0.2" %}
+{% set version = "5.0.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,9 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ffea98b29c6a7d25a4296eed400b491c89fd89365806a0f646ede44c043727fa
+  sha256: 2586bcb61d29d76e89e563a6836df24d86939961c9657f129a59f7617de45377
 
 build:
-  noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -18,6 +17,8 @@ requirements:
   host:
     - python
     - pip
+    - wheel
+    - setuptools
   run:
     - python
     # for long_description_content_type
@@ -33,7 +34,11 @@ about:
   license_family: MIT
   license_file: LICENSE.txt
   summary: A Python implementation of HSLuv (revision 4).
-
+  description: |
+    HSLuv is a human-friendly alternative to HSL implemented
+    in Python (revision 4).
+  doc_url: https://github.com/hsluv/hsluv-python
+  dev_url: https://github.com/hsluv/hsluv-python
 extra:
   recipe-maintainers:
     - hmaarrfk

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<36]
 
 requirements:
   host:


### PR DESCRIPTION
* update to 5.0.3

sadly, version 5.0.2 is no longer avaiable in internet.  so for python 3.11 build-out we need to update it to newer version (with some bug-fixes)